### PR TITLE
Fix travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: bash
+language: ruby
+rvm:
+  - 2.6
 sudo: true
 os: osx
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os: osx
 install:
   - brew tap issmirnov/apps
   - brew update
-  - brew install issmirnov/apps/zap" 
+  - brew install issmirnov/apps/zap
 
 script:
   - export HOMEBREW_NO_AUTO_UPDATE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 rvm:
   - 2.6
 sudo: true
+env: OSX=10.12
+osx_image: xcode8.3
+sudo: required
 os: osx
   
 install:
@@ -10,6 +13,7 @@ install:
   - brew install issmirnov/apps/zap" 
 
 script:
+  - export HOMEBREW_NO_AUTO_UPDATE=1
   - sudo brew services start issmirnov/apps/zap
   - "curl -s -o /dev/null -w '%{http_code} %{redirect_url}\n' -H 'Host: g' localhost/z"
   - "brew audit --strict --online zap"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.6
 sudo: true
 env: OSX=10.12
-osx_image: xcode8.3
+osx_image: xcode10.3
 sudo: required
 os: osx
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,11 @@ sudo: required
 os: osx
   
 install:
+  - export HOMEBREW_NO_AUTO_UPDATE=1
   - brew tap issmirnov/apps
-  - brew update
   - brew install issmirnov/apps/zap
 
 script:
-  - export HOMEBREW_NO_AUTO_UPDATE=1
   - sudo brew services start issmirnov/apps/zap
   - "curl -s -o /dev/null -w '%{http_code} %{redirect_url}\n' -H 'Host: g' localhost/z"
   - "brew audit --strict --online zap"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os: osx
   
 install:
   - brew tap issmirnov/apps
-  - "HOMEBREW_NO_AUTO_UPDATE=1 brew install issmirnov/apps/zap" 
+  - brew update
+  - brew install issmirnov/apps/zap" 
 
 script:
   - sudo brew services start issmirnov/apps/zap


### PR DESCRIPTION
Travis is failing with the error "Homebrew must be run under Ruby 2.6! You're running 2.3.3." 

Docs indicate I should allow brew to update, and then this problem will be gone. This will slow down builds, but since they are infrequent I can live with that.